### PR TITLE
Add WalletTransaction model and update Wallet

### DIFF
--- a/app/Models/Wallet.php
+++ b/app/Models/Wallet.php
@@ -5,16 +5,15 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Models\BaseModel as Model;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use App\Models\WalletTransaction;
 
 class Wallet extends Model
 {
     use HasUuids,HasFactory;
     public $fillable = [
-        'id',
         'user_id',
+        'balance',
         'type',
-        'credit',
-        'debit',
     ];
 
 
@@ -39,5 +38,10 @@ class Wallet extends Model
     public function getUser()
     {
         return $this->hasOne(User::class, 'id','user_id');
+    }
+
+    public function transactions()
+    {
+        return $this->hasMany(WalletTransaction::class);
     }
 }

--- a/app/Models/WalletTransaction.php
+++ b/app/Models/WalletTransaction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use App\Models\BaseModel as Model;
+
+class WalletTransaction extends Model
+{
+    use HasFactory, HasUuids;
+
+    public $fillable = [
+        'id',
+        'wallet_id',
+        'type',
+        'credit',
+        'debit',
+        'status',
+        'note',
+    ];
+
+    public function wallet()
+    {
+        return $this->belongsTo(Wallet::class);
+    }
+}


### PR DESCRIPTION
## Summary
- allow wallets to store user_id, balance and type only
- add transactions() relation to wallets
- implement new WalletTransaction model with wallet relationship

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e6873cde88329b428a1a04110ab4e