### PR TITLE
Fix product model namespaces

### DIFF
--- a/app/Http/Controllers/Payment/CheckoutController.php
+++ b/app/Http/Controllers/Payment/CheckoutController.php
@@ -4,7 +4,8 @@ namespace App\Http\Controllers\Payment;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use App\Models\Frontend\{Product,ProductMeta};
+use App\Models\Product;
+use App\Models\Frontend\ProductMeta;
 use App\Models\{Order,OrderProduct,Wallet,User};
 use Cart,Redirect, Session,Str,Storage,Auth,Hash;
 use LaravelDaily\Invoices\Invoice;

--- a/app/Models/OrderProduct.php
+++ b/app/Models/OrderProduct.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Models\BaseModel as Model;
-use App\Models\Frontend\{Product};
+use App\Models\Product;
 class OrderProduct extends Model
 {
     use HasFactory;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use App\Models\Frontend\{Product};
+use App\Models\Product;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class User extends Authenticatable


### PR DESCRIPTION
## Summary
- use `App\Models\Product` in checkout and model classes instead of `App\Models\Frontend\Product`

## Testing
- `phpunit -c phpunit.xml` *(fails: Expected response status code [302] but received 500)*

------
https://chatgpt.com/codex/tasks/task_b_684e6fb111d883299adae58b296b23a6