### PR TITLE
Fix wallet balance usage

### DIFF
--- a/app/Http/Controllers/Author/AuthorViewController.php
+++ b/app/Http/Controllers/Author/AuthorViewController.php
@@ -4,7 +4,8 @@ namespace App\Http\Controllers\Author;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use App\Models\{User,ProductAnalysis,Order,OrderProduct,UserAdditionalInfo,Wallet};
+use App\Models\{User,ProductAnalysis,Order,OrderProduct,UserAdditionalInfo,Wallet,WalletTransaction};
+use App\Services\WalletService;
 use App\Models\Admin\DiscountCoupon;
 use App\Models\Product;
 use Auth;
@@ -12,6 +13,12 @@ use App\Charts\DashboardChart;
 use Carbon\Carbon;
 class AuthorViewController extends Controller
 {
+    private WalletService $walletService;
+
+    public function __construct(WalletService $walletService)
+    {
+        $this->walletService = $walletService;
+    }
 
     //Author login page
     public function login_view()
@@ -55,9 +62,11 @@ class AuthorViewController extends Controller
         $data['total_product_view'] = $ProductAnalysisQuery->where('user_id',$user->id)->count();
         $data['total_product_sale']= $OrderProduct->count();
         $data['total_product_sale_amount']=  $Order->where('vendor_id',$user->id)->sum('vendor_amount');
-        $wallet = new Wallet();
-        $data['available_balance'] = $wallet->where('user_id',$user->id)->select(\DB::raw('SUM(credit - debit) as total'))->value('total');
-        $data['withdraw_amount'] = $wallet->where(['user_id'=>$user->id,'status'=>1])->sum('debit');
+        $data['available_balance'] = $this->walletService->getBalance($user->id);
+
+        $data['withdraw_amount'] = WalletTransaction::whereHas('wallet', function($q) use ($user) {
+            $q->where('user_id', $user->id);
+        })->where('type', 'debit')->sum('amount');
     
         $mobile = $ProductAnalysis->where('user_id',$user->id)->where('device','Mobile')->count();
         $desktop = $ProductAnalysis->where('user_id',$user->id)->where('device','Desktop')->count();

--- a/resources/views/admin/wallet/edit_request.blade.php
+++ b/resources/views/admin/wallet/edit_request.blade.php
@@ -23,21 +23,21 @@
                                 </div>
                                 <div class="th_product_detail">
                                     <div class="theme_label">ID người dùng :</div>
-                                    <div class="product_info product_name">{{ @$data->user_id }}</div>
+                                    <div class="product_info product_name">{{ @$data->wallet->user_id }}</div>
                                 </div>
 
                                 <div class="th_product_detail">
                                     <div class="theme_label">Họ và tên :</div>
-                                    <div class="product_info product_name">{{ @$data->getUser->full_name }}</div>
+                                    <div class="product_info product_name">{{ @$data->wallet->getUser->full_name }}</div>
                                 </div>
                                 <div class="th_product_detail">
                                     <div class="theme_label">Email :</div>
-                                    <div class="product_info product_name">{{ @$data->getUser->email }}</div>
+                                    <div class="product_info product_name">{{ @$data->wallet->getUser->email }}</div>
                                 </div>
 
                                 <div class="th_product_detail">
                                     <div class="theme_label">Số tiền rút :</div>
-                                    <div class="product_info product_name">{{ number_format(@$data->debit, 0, ',', '.') }} Scoin</div>
+                                    <div class="product_info product_name">{{ number_format(@$data->amount, 0, ',', '.') }} Scoin</div>
                                 </div>
 
                                 <div class="th_product_detail">
@@ -103,7 +103,7 @@
                                         <div class="col tp_form_wrapper">
                                             <label class="mb-2">Ghi chú</label>
                                             <textarea class="form-textarea" rows="5" cols="50" spellcheck="false" name="note"
-                                                placeholder="Nhập ghi chú">{{ @$data->note }}</textarea>
+                                                placeholder="Nhập ghi chú">{{ @$data->description }}</textarea>
                                         </div>
                                     </div>
                                 </div>

--- a/resources/views/admin/wallet/index.blade.php
+++ b/resources/views/admin/wallet/index.blade.php
@@ -38,11 +38,11 @@
                                         @foreach ($data as $key => $item)
                                             <tr id="table_row_{{ $item->id }}">
                                                 <td>{{ ++$key }}</td>
-                                                <td>{{ $item->getUser->full_name }}</td>
-                                                <td>{{ $item->getUser->email }}</td>
+                                                <td>{{ $item->wallet->getUser->full_name }}</td>
+                                                <td>{{ $item->wallet->getUser->email }}</td>
                                                 <td>{{ $item->type }}</td>
-                                                <td>{{ number_format(@$item->credit, 0, ',', '.') }} Scoin</td>
-                                                <td>{{ number_format($item->debit, 0, ',', '.') }} Scoin</td>
+                                                <td>{{ $item->type == 'credit' ? number_format($item->amount, 0, ',', '.') : '-' }} Scoin</td>
+                                                <td>{{ $item->type == 'debit' ? number_format($item->amount, 0, ',', '.') : '-' }} Scoin</td>
                                                 <td>{{ $item->created_at }}</td>
                                                 <td>
                                                     <ul>

--- a/resources/views/admin/wallet/show.blade.php
+++ b/resources/views/admin/wallet/show.blade.php
@@ -23,15 +23,15 @@
                                 </div>
                                 <div class="th_product_detail">
                                     <div class="theme_label">ID người dùng :</div>
-                                    <div class="product_info product_name">{{ @$data->user_id }}</div>
+                                    <div class="product_info product_name">{{ @$data->wallet->user_id }}</div>
                                 </div>
                                 <div class="th_product_detail">
                                     <div class="theme_label">Họ và tên :</div>
-                                    <div class="product_info product_name">{{ @$data->getUser->full_name }}</div>
+                                    <div class="product_info product_name">{{ @$data->wallet->getUser->full_name }}</div>
                                 </div>
                                 <div class="th_product_detail">
                                     <div class="theme_label">Email :</div>
-                                    <div class="product_info product_name">{{ @$data->getUser->email }}</div>
+                                    <div class="product_info product_name">{{ @$data->wallet->getUser->email }}</div>
                                 </div>
 
                                 <div class="th_product_detail">
@@ -40,11 +40,11 @@
                                 </div>
                                 <div class="th_product_detail">
                                     <div class="theme_label">Tiền cộng :</div>
-                                    <div class="product_info product_name">{{ number_format($data->credit ?? 0, 0, ',', '.') }} Scoin</div>
+                                    <div class="product_info product_name">{{ $data->type == 'credit' ? number_format($data->amount, 0, ',', '.') : '-' }} Scoin</div>
                                 </div>
                                 <div class="th_product_detail">
                                     <div class="theme_label">Tiền trừ :</div>
-                                    <div class="product_info product_name">{{ number_format($data->debit ?? 0, 0, ',', '.') }} Scoin</div>
+                                    <div class="product_info product_name">{{ $data->type == 'debit' ? number_format($data->amount, 0, ',', '.') : '-' }} Scoin</div>
                                 </div>
                         
                                 <div class="th_product_detail">
@@ -59,7 +59,7 @@
                                     </div>
                                     <div class="th_product_detail">
                                         <div class="theme_label">Ghi chú :</div>
-                                        <div class="product_info product_name">{{ @$data->note ?? '-'}}
+                                        <div class="product_info product_name">{{ @$data->description ?? '-'}}
                                         </div>
                                     </div>
 

--- a/resources/views/admin/wallet/withdraw_request.blade.php
+++ b/resources/views/admin/wallet/withdraw_request.blade.php
@@ -37,11 +37,11 @@
                                         @foreach ($data as $key => $item)
                                             <tr id="table_row_{{ $item->id }}">
                                                 <td>{{ ++$key }}</td>
-                                                <td>{{ $item->getUser->full_name }}</td>
-                                                <td>{{ $item->getUser->email }}</td>
-                                                <td>{{ number_format($item->debit, 0, ',', '.') }} Scoin</td>
+                                                <td>{{ $item->wallet->getUser->full_name }}</td>
+                                                <td>{{ $item->wallet->getUser->email }}</td>
+                                                <td>{{ number_format($item->amount, 0, ',', '.') }} Scoin</td>
                                                 <td>{{ $item->created_at }}</td>
-                                                <td>{{ $item->type == 'WITHDRAW' ? $item->status_str : '-' }}</td>
+                                                <td>{{ $item->status_str ?? '-' }}</td>
                                                 <td>
                                                     <ul>
                                                         <li><a href="{{ route('admin.wallet.edit-request', $item->id) }}"

--- a/resources/views/author/wallet/index.blade.php
+++ b/resources/views/author/wallet/index.blade.php
@@ -69,16 +69,16 @@
                                             <tr id="table_row_{{ $item->id }}">
                                                 <td>{{ ++$key }}</td>
                                                 <td>
-                                                    @if($item->type == "WITHDRAW")  
-                                                    <span class="text-danger"> {{$item->type}} <span>
+                                                    @if($item->type == 'debit')
+                                                    <span class="text-danger"> {{ strtoupper($item->type) }} <span>
                                                     @else
-                                                    <span class="text-success"> {{$item->type}} <span>
+                                                    <span class="text-success"> {{ strtoupper($item->type) }} <span>
                                                     @endif
                                                 </td>
-                                                <td>{{ number_format(@$item->credit, 0, ',', '.') }} Scoin</td>
-                                                <td>{{ number_format($item->debit, 0, ',', '.') }} Scoin</td>
+                                                <td>{{ $item->type == 'credit' ? number_format($item->amount, 0, ',', '.') : '-' }} Scoin</td>
+                                                <td>{{ $item->type == 'debit' ? number_format($item->amount, 0, ',', '.') : '-' }} Scoin</td>
                                                 <td>{{ $item->created_at }}</td>
-                                                <td>{{ ($item->type == "WITHDRAW") ? $item->status_str : 'Đã cộng tiền'}}</td>
+                                                <td>{{ $item->type == 'debit' ? $item->status_str : 'Đã cộng tiền'}}</td>
                                                 <td>
                                                     <ul>
                                                         <li><a href="{{ route('vendor.wallet.show', $item->id) }}"

--- a/resources/views/author/wallet/show.blade.php
+++ b/resources/views/author/wallet/show.blade.php
@@ -25,12 +25,12 @@
                                 </div>
                                 <div class="th_product_detail">
                                     <div class="theme_label">Ghi có :</div>
-                                    <div class="product_info product_name">{{ number_format($data->credit ?? 0, 0, ',', '.') }} Scoin
+                                    <div class="product_info product_name">{{ $data->type == 'credit' ? number_format($data->amount ?? 0, 0, ',', '.') : '-' }} Scoin
                                     </div>
                                 </div>
                                 <div class="th_product_detail">
                                     <div class="theme_label">Ghi nợ :</div>
-                                    <div class="product_info product_name">{{ number_format($data->debit ?? 0, 0, ',', '.') }} Scoin
+                                    <div class="product_info product_name">{{ $data->type == 'debit' ? number_format($data->amount ?? 0, 0, ',', '.') : '-' }} Scoin
                                     </div>
                                 </div>
                         
@@ -46,7 +46,7 @@
                                 </div>
                                 <div class="th_product_detail">
                                     <div class="theme_label">Ghi chú :</div>
-                                    <div class="product_info product_name">{{ @$data->note ?? '-'}}
+                                    <div class="product_info product_name">{{ @$data->description ?? '-'}}
                                     </div>
                                 </div>
 


### PR DESCRIPTION
## Summary
- set up Author controllers to rely on `WalletService` and transactions
- display wallet balances from `wallets.balance`
- use `wallet_transactions` for withdrawals
- drop old `credit`/`debit` column usage in admin and author views

## Testing
- `phpunit` *(fails: `bash: ./vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_684e82b747508329b5715ef1806e0a53