### PR TITLE
Update WalletService to create wallet on debit

### DIFF
--- a/app/Services/WalletService.php
+++ b/app/Services/WalletService.php
@@ -48,9 +48,16 @@ class WalletService
     public function debit(int $userId, float $amount, string $source, ?string $desc = null)
     {
         return DB::transaction(function () use ($userId, $amount, $source, $desc) {
-            $wallet = Wallet::where('user_id', $userId)->first();
+            $wallet = Wallet::firstOrCreate(
+                ['user_id' => $userId],
+                [
+                    'id' => Str::uuid()->toString(),
+                    'balance' => 0,
+                    'type' => 'DEFAULT',
+                ]
+            );
 
-            $balance = $wallet?->balance ?? 0;
+            $balance = $wallet->balance;
             if ($balance < $amount) {
                 throw new \Exception('Insufficient balance');
             }


### PR DESCRIPTION
## Summary
- ensure WalletService `debit()` creates a wallet record if none exists
- keep transactions recorded with wallet ID and adjust wallet balances
- add tests for wallet service

## Testing
- `./vendor/bin/phpunit --filter WalletServiceTest`

------
https://chatgpt.com/codex/tasks/task_b_684e82bda1f8832981e0da6bdde0f549