### PR TITLE
Update wallet transaction model

### DIFF
--- a/app/Http/Controllers/ADMIN/WalletController.php
+++ b/app/Http/Controllers/ADMIN/WalletController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\ADMIN;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use App\Models\{Wallet,Setting,UserAdditionalInfo};
+use App\Models\{Wallet,WalletTransaction,Setting,UserAdditionalInfo};
 
 class WalletController extends Controller
 {
@@ -13,10 +13,10 @@ class WalletController extends Controller
      */
     public function index()
     {
-        $Obj = new Wallet();
+        $Obj = new WalletTransaction();
         $data['data'] =  $Obj->filter()->orderBy('id','DESC')->paginate(10);
-        $data['total_amount'] = $Obj->sum(\DB::raw('credit', '-', 'debit'));
-        $data['searchable'] =  Wallet::$searchable;
+        $data['total_amount'] = $Obj->sum('amount');
+        $data['searchable'] =  [];
         return view('admin.wallet.index',$data);
     }
 
@@ -25,9 +25,9 @@ class WalletController extends Controller
      */
     public function withdraw_request()
     {
-        $Obj = new Wallet();
-        $data['data'] =  $Obj->filter()->where('type','WITHDRAW')->orderBy('id','DESC')->paginate(10);
-        $data['searchable'] =  Wallet::$searchable;
+        $Obj = new WalletTransaction();
+        $data['data'] =  $Obj->filter()->where('source','WITHDRAW')->orderBy('id','DESC')->paginate(10);
+        $data['searchable'] =  [];
         return view('admin.wallet.withdraw_request',$data);
     }
 
@@ -45,7 +45,7 @@ class WalletController extends Controller
      */
     public function show(string $id)
     {
-        $data = Wallet::find($id);
+        $data = WalletTransaction::find($id);
         if(empty($data)){
             return redirect()->route('admin.wallet.index');
         }
@@ -58,7 +58,7 @@ class WalletController extends Controller
      */
     public function  edit_request(string $id)
     {
-        $data = Wallet::find($id);
+        $data = WalletTransaction::find($id);
         if(empty($data)){
             return redirect()->route('admin.wallet.withdraw-request');
         }
@@ -70,7 +70,7 @@ class WalletController extends Controller
 
     public function  update_request(request $request)
     {
-        $data = Wallet::find($request->id);
+        $data = WalletTransaction::find($request->id);
         if(empty($data)){
             return redirect()->route('admin.wallet.withdraw-request');
         }

--- a/app/Http/Controllers/Author/AuthorViewController.php
+++ b/app/Http/Controllers/Author/AuthorViewController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Author;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use App\Models\{User,ProductAnalysis,Order,OrderProduct,UserAdditionalInfo,Wallet};
+use App\Models\{User,ProductAnalysis,Order,OrderProduct,UserAdditionalInfo,Wallet,WalletTransaction};
 use App\Models\Admin\DiscountCoupon;
 use App\Models\Product;
 use Auth;
@@ -55,9 +55,11 @@ class AuthorViewController extends Controller
         $data['total_product_view'] = $ProductAnalysisQuery->where('user_id',$user->id)->count();
         $data['total_product_sale']= $OrderProduct->count();
         $data['total_product_sale_amount']=  $Order->where('vendor_id',$user->id)->sum('vendor_amount');
-        $wallet = new Wallet();
-        $data['available_balance'] = $wallet->where('user_id',$user->id)->select(\DB::raw('SUM(credit - debit) as total'))->value('total');
-        $data['withdraw_amount'] = $wallet->where(['user_id'=>$user->id,'status'=>1])->sum('debit');
+        $wallet = Wallet::where('user_id', $user->id)->first();
+        $data['available_balance'] = $wallet->balance ?? 0;
+        $data['withdraw_amount'] = WalletTransaction::where('wallet_id', $wallet->id ?? '')
+            ->where('type', 'debit')
+            ->sum('amount');
     
         $mobile = $ProductAnalysis->where('user_id',$user->id)->where('device','Mobile')->count();
         $desktop = $ProductAnalysis->where('user_id',$user->id)->where('device','Desktop')->count();

--- a/app/Http/Controllers/Author/WalletController.php
+++ b/app/Http/Controllers/Author/WalletController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Author;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use App\Models\{Wallet};
+use App\Models\{Wallet, WalletTransaction};
 use App\Services\WalletService;
 use Validator;
 
@@ -22,13 +22,21 @@ class WalletController extends Controller
     public function index()
     {
         $user = auth()->user();
-        $Obj = new Wallet();
-        $data['data'] =  $Obj->filter()->where('user_id',$user->id)->orderBy('id','DESC')->paginate(10);
+        $wallet = Wallet::where('user_id', $user->id)->first();
 
-        $data['total_amount'] = $Obj->where('user_id',$user->id)->select(\DB::raw('SUM(credit - debit) as total'))->value('total');
-        $data['withdraw_amount'] = $Obj->where(['user_id'=>$user->id,'status'=>1])->sum('debit');
-    
-        $data['searchable'] =  Wallet::$searchable;
+        $transactions = WalletTransaction::query();
+        if ($wallet) {
+            $transactions->where('wallet_id', $wallet->id);
+        }
+
+        $data['data'] = $transactions->filter()->orderBy('id', 'DESC')->paginate(10);
+
+        $data['total_amount'] = $wallet->balance ?? 0;
+        $data['withdraw_amount'] = WalletTransaction::where('wallet_id', $wallet->id ?? '')
+            ->where('type', 'debit')
+            ->where('status', 1)
+            ->sum('amount');
+
         return view('author.wallet.index',$data);
     }
 
@@ -37,7 +45,7 @@ class WalletController extends Controller
      */
     public function show(string $id)
     {
-        $data = Wallet::find($id);
+        $data = WalletTransaction::find($id);
         if(empty($data)){
             return redirect()->route('vendor.wallet.index');
         }

--- a/app/Models/WalletTransaction.php
+++ b/app/Models/WalletTransaction.php
@@ -23,6 +23,7 @@ class WalletTransaction extends Model
      * @var array<int, string>
      */
     public $fillable = [
+        'id',
         'wallet_id',
         'amount',
         'type',
@@ -34,5 +35,14 @@ class WalletTransaction extends Model
     public function wallet()
     {
         return $this->belongsTo(Wallet::class);
+    }
+
+    public function getStatusStrAttribute()
+    {
+        return match ($this->status) {
+            1 => 'Withdrawal completed!',
+            2 => 'Reject',
+            default => 'Pending',
+        };
     }
 }

--- a/resources/views/admin/wallet/edit_request.blade.php
+++ b/resources/views/admin/wallet/edit_request.blade.php
@@ -37,7 +37,7 @@
 
                                 <div class="th_product_detail">
                                     <div class="theme_label">Số tiền rút :</div>
-                                    <div class="product_info product_name">{{ number_format(@$data->debit, 0, ',', '.') }} Scoin</div>
+                                    <div class="product_info product_name">{{ number_format(@$data->amount, 0, ',', '.') }} Scoin</div>
                                 </div>
 
                                 <div class="th_product_detail">

--- a/resources/views/admin/wallet/index.blade.php
+++ b/resources/views/admin/wallet/index.blade.php
@@ -41,8 +41,8 @@
                                                 <td>{{ $item->getUser->full_name }}</td>
                                                 <td>{{ $item->getUser->email }}</td>
                                                 <td>{{ $item->type }}</td>
-                                                <td>{{ number_format(@$item->credit, 0, ',', '.') }} Scoin</td>
-                                                <td>{{ number_format($item->debit, 0, ',', '.') }} Scoin</td>
+                                                <td>{{ $item->type == 'credit' ? number_format($item->amount, 0, ',', '.') . ' Scoin' : '-' }}</td>
+                                                <td>{{ $item->type == 'debit' ? number_format($item->amount, 0, ',', '.') . ' Scoin' : '-' }}</td>
                                                 <td>{{ $item->created_at }}</td>
                                                 <td>
                                                     <ul>

--- a/resources/views/admin/wallet/show.blade.php
+++ b/resources/views/admin/wallet/show.blade.php
@@ -39,12 +39,8 @@
                                     <div class="product_info product_name">{{ $data->type }}</div>
                                 </div>
                                 <div class="th_product_detail">
-                                    <div class="theme_label">Tiền cộng :</div>
-                                    <div class="product_info product_name">{{ number_format($data->credit ?? 0, 0, ',', '.') }} Scoin</div>
-                                </div>
-                                <div class="th_product_detail">
-                                    <div class="theme_label">Tiền trừ :</div>
-                                    <div class="product_info product_name">{{ number_format($data->debit ?? 0, 0, ',', '.') }} Scoin</div>
+                                    <div class="theme_label">Số tiền :</div>
+                                    <div class="product_info product_name">{{ number_format($data->amount ?? 0, 0, ',', '.') }} Scoin</div>
                                 </div>
                         
                                 <div class="th_product_detail">

--- a/resources/views/admin/wallet/withdraw_request.blade.php
+++ b/resources/views/admin/wallet/withdraw_request.blade.php
@@ -39,7 +39,7 @@
                                                 <td>{{ ++$key }}</td>
                                                 <td>{{ $item->getUser->full_name }}</td>
                                                 <td>{{ $item->getUser->email }}</td>
-                                                <td>{{ number_format($item->debit, 0, ',', '.') }} Scoin</td>
+                                                <td>{{ number_format($item->amount, 0, ',', '.') }} Scoin</td>
                                                 <td>{{ $item->created_at }}</td>
                                                 <td>{{ $item->type == 'WITHDRAW' ? $item->status_str : '-' }}</td>
                                                 <td>

--- a/resources/views/author/wallet/index.blade.php
+++ b/resources/views/author/wallet/index.blade.php
@@ -75,8 +75,8 @@
                                                     <span class="text-success"> {{$item->type}} <span>
                                                     @endif
                                                 </td>
-                                                <td>{{ number_format(@$item->credit, 0, ',', '.') }} Scoin</td>
-                                                <td>{{ number_format($item->debit, 0, ',', '.') }} Scoin</td>
+                                                <td>{{ $item->type == 'credit' ? number_format($item->amount, 0, ',', '.') . ' Scoin' : '-' }}</td>
+                                                <td>{{ $item->type == 'debit' ? number_format($item->amount, 0, ',', '.') . ' Scoin' : '-' }}</td>
                                                 <td>{{ $item->created_at }}</td>
                                                 <td>{{ ($item->type == "WITHDRAW") ? $item->status_str : 'Đã cộng tiền'}}</td>
                                                 <td>

--- a/resources/views/author/wallet/show.blade.php
+++ b/resources/views/author/wallet/show.blade.php
@@ -24,13 +24,8 @@
                                     <div class="product_info product_name">{{ $data->type }}</div>
                                 </div>
                                 <div class="th_product_detail">
-                                    <div class="theme_label">Ghi có :</div>
-                                    <div class="product_info product_name">{{ number_format($data->credit ?? 0, 0, ',', '.') }} Scoin
-                                    </div>
-                                </div>
-                                <div class="th_product_detail">
-                                    <div class="theme_label">Ghi nợ :</div>
-                                    <div class="product_info product_name">{{ number_format($data->debit ?? 0, 0, ',', '.') }} Scoin
+                                    <div class="theme_label">Số tiền :</div>
+                                    <div class="product_info product_name">{{ number_format($data->amount ?? 0, 0, ',', '.') }} Scoin
                                     </div>
                                 </div>
                         


### PR DESCRIPTION
## Summary
- add `id` to wallet transaction fillable and expose status helper
- switch wallet controllers to use `wallet_transactions` table
- update views to display new `amount` field
- fix dashboard balance calculations

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e82cb70b0832998a7a36ac805a8b4