### PR TITLE
Add wallet route and service integration

### DIFF
--- a/app/Http/Controllers/Frontend/WalletController.php
+++ b/app/Http/Controllers/Frontend/WalletController.php
@@ -4,11 +4,16 @@ namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Str;
-use App\Models\Wallet;
+use App\Services\WalletService;
 
 class WalletController extends Controller
 {
+    private WalletService $walletService;
+
+    public function __construct(WalletService $walletService)
+    {
+        $this->walletService = $walletService;
+    }
     /**
      * Display the authenticated user's wallet and transactions.
      */
@@ -16,16 +21,7 @@ class WalletController extends Controller
     {
         $user = Auth::user();
 
-        $wallet = Wallet::firstOrCreate(
-            ['user_id' => $user->id],
-            [
-                'id' => Str::uuid()->toString(),
-                'balance' => 0,
-                'type' => 'DEFAULT',
-            ]
-        );
-
-        $transactions = $wallet->transactions()->orderByDesc('created_at')->paginate(10);
+        [$wallet, $transactions] = $this->walletService->getWalletWithTransactions($user->id);
 
         return view('frontend.wallet.index', compact('wallet', 'transactions'));
     }

--- a/app/Services/WalletService.php
+++ b/app/Services/WalletService.php
@@ -79,4 +79,23 @@ class WalletService
     {
         return Wallet::where('user_id', $userId)->value('balance') ?? 0;
     }
+
+    /**
+     * Retrieve wallet and paginated transactions for a user.
+     */
+    public function getWalletWithTransactions(int $userId, int $perPage = 10): array
+    {
+        $wallet = Wallet::firstOrCreate(
+            ['user_id' => $userId],
+            [
+                'id' => Str::uuid()->toString(),
+                'balance' => 0,
+                'type' => 'DEFAULT',
+            ]
+        );
+
+        $transactions = $wallet->transactions()->orderByDesc('created_at')->paginate($perPage);
+
+        return [$wallet, $transactions];
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\ADMIN\{AdminViewController, AdminController,PageController,ProductCategoryController,ProductSubCategoryController,UsersController,VendorController,EmailIntegrationsController,ProductController,SettingController,TestimonialController,DiscountCouponController,OrderController,HomeContentController,MailController,LocaleFileController,WalletController};
-use App\Http\Controllers\Frontend\{CouponsController,HomeController,ProductController as FrontendProductController, HomeViewController,UserController,CartController,CommentController,SocialLoginController,WalletController as FrontendWalletController};
+use App\Http\Controllers\ADMIN\{AdminViewController, AdminController,PageController,ProductCategoryController,ProductSubCategoryController,UsersController,VendorController,EmailIntegrationsController,ProductController,SettingController,TestimonialController,DiscountCouponController,OrderController,HomeContentController,MailController,LocaleFileController,WalletController as AdminWalletController};
+use App\Http\Controllers\Frontend\{CouponsController,HomeController,ProductController as FrontendProductController, HomeViewController,UserController,CartController,CommentController,SocialLoginController,WalletController};
 use App\Http\Controllers\Payment\{CheckoutController,PaymentsController,PayPalPaymentController,FlutterwaveController,StripePaymentController,RazorpayController,PawaPayController};
 use Laravel\Socialite\Facades\Socialite;
 /*
@@ -204,7 +204,7 @@ Route::group(['prefix' => 'admin'], function () {
         Route::post('/send_mail', [MailController::class, 'send_mail'])->name('admin.email.sendmail');
 
         /* Wallet routes */
-        Route::controller(WalletController::class)->prefix('wallet')->group(function(){
+        Route::controller(AdminWalletController::class)->prefix('wallet')->group(function(){
             Route::get('/', 'index')->name('admin.wallet.index');
             Route::get('show/{id}', 'show')->name('admin.wallet.show');
             Route::get('withdraw-request', 'withdraw_request')->name('admin.wallet.withdraw-request');
@@ -311,7 +311,7 @@ Route::group(
                 Route::post('/become-an-vendor-request',  'become_an_vendor_request')->name('frontend.become-an-vendor-request');
             });
 
-            Route::get('/wallet', [FrontendWalletController::class, 'index'])->name('frontend.wallet');
+            Route::get('/wallet', [WalletController::class, 'index'])->name('frontend.wallet');
          
             //coupon code apply
             Route::post('/post-coupon-code', [CouponsController::class, 'checkCouponCode'])->name('frontend.coupon.apply');
@@ -393,6 +393,10 @@ Route::get('/facebook/callback', [SocialLoginController::class, 'facebookCallbac
 include  __DIR__.'/vendor_web.php';
 
 /* Vendor Routes End */
+
+Route::middleware('auth')->group(function () {
+    Route::get('/wallet', [WalletController::class, 'index'])->name('wallet.index');
+});
 
 Route::get('/cache', function () {
     Artisan::call('cache:clear');


### PR DESCRIPTION
## Summary
- alias admin wallet controller to avoid conflict
- use WalletService in frontend wallet controller
- expose helper to load wallet with transactions in WalletService
- register `/wallet` route under auth middleware

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684e82d10830832980ab7252a362544a