### PR TITLE
Implement wallet top-up flow

### DIFF
--- a/app/Http/Controllers/Frontend/TopUpController.php
+++ b/app/Http/Controllers/Frontend/TopUpController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Frontend;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use App\Models\Wallet;
+
+class TopUpController extends Controller
+{
+    public function create()
+    {
+        $user = Auth::user();
+        $wallet = Wallet::firstOrCreate(
+            ['user_id' => $user->id],
+            [
+                'id' => Str::uuid()->toString(),
+                'balance' => 0,
+                'type' => 'DEFAULT',
+            ]
+        );
+        return view('frontend.topup.create', compact('wallet'));
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'amount' => 'required|numeric|min:10000',
+        ]);
+
+        $user = $request->user();
+        $wallet = Wallet::firstOrCreate(
+            ['user_id' => $user->id],
+            [
+                'id' => Str::uuid()->toString(),
+                'balance' => 0,
+                'type' => 'DEFAULT',
+            ]
+        );
+
+        DB::table('wallet_transactions')->insert([
+            'id' => Str::uuid()->toString(),
+            'wallet_id' => $wallet->id,
+            'amount' => $validated['amount'],
+            'type' => 'credit',
+            'source' => 'topup',
+            'status' => 0,
+            'description' => 'Top up request',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return redirect()
+            ->route('wallet.topup.create')
+            ->with('success', 'Yêu cầu nạp tiền đã được ghi nhận');
+    }
+}

--- a/resources/views/frontend/layout/nav.blade.php
+++ b/resources/views/frontend/layout/nav.blade.php
@@ -148,6 +148,9 @@
                             <li>
                                 <a class="dropdown-item" href="{{ route('frontend.wallet', app()->getLocale()) }}">Ví Scoin</a>
                             </li>
+                            <li>
+                                <a class="dropdown-item" href="{{ route('wallet.topup.create') }}">Nạp Scoin</a>
+                            </li>
                             @if (getSettingLongText()->is_checked_author_tab)
                             <li>
                                 <a class="dropdown-item"

--- a/resources/views/frontend/topup/create.blade.php
+++ b/resources/views/frontend/topup/create.blade.php
@@ -1,0 +1,32 @@
+@extends('frontend.layout.master')
+
+@section('head_scripts')
+    <title>Nạp Scoin</title>
+@endsection
+
+@section('content')
+<div class="tp_singlepage_section tp_cart_wrapper">
+    <div class="container">
+        <div class="row mb-4">
+            <div class="col-12">
+                <h2>Nạp Scoin</h2>
+            </div>
+        </div>
+        @if(session('success'))
+            <div class="alert alert-success">{{ session('success') }}</div>
+        @endif
+        <div class="row">
+            <div class="col-md-6">
+                <form action="{{ route('wallet.topup.store') }}" method="POST">
+                    @csrf
+                    <div class="mb-3">
+                        <label for="amount" class="form-label">Số tiền (VND)</label>
+                        <input type="number" class="form-control" id="amount" name="amount" min="10000" required>
+                    </div>
+                    <button type="submit" class="tp_btn">Nạp Scoin</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/frontend/wallet/index.blade.php
+++ b/resources/views/frontend/wallet/index.blade.php
@@ -11,6 +11,7 @@
             <div class="col-12">
                 <h2>Ví Scoin</h2>
                 <p>Số dư hiện tại: <strong>{{ number_format($wallet->balance, 0, ',', '.') }} Scoin</strong></p>
+                <a href="{{ route('wallet.topup.create') }}" class="tp_btn mt-2">Nạp Scoin</a>
             </div>
         </div>
         <div class="row">

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ADMIN\{AdminViewController, AdminController,PageController,ProductCategoryController,ProductSubCategoryController,UsersController,VendorController,EmailIntegrationsController,ProductController,SettingController,TestimonialController,DiscountCouponController,OrderController,HomeContentController,MailController,LocaleFileController,WalletController as AdminWalletController};
-use App\Http\Controllers\Frontend\{CouponsController,HomeController,ProductController as FrontendProductController, HomeViewController,UserController,CartController,CommentController,SocialLoginController,WalletController};
+use App\Http\Controllers\Frontend\{CouponsController,HomeController,ProductController as FrontendProductController, HomeViewController,UserController,CartController,CommentController,SocialLoginController,WalletController,TopUpController};
 use App\Http\Controllers\Payment\{CheckoutController,PaymentsController,PayPalPaymentController,FlutterwaveController,StripePaymentController,RazorpayController,PawaPayController};
 use Laravel\Socialite\Facades\Socialite;
 /*
@@ -396,6 +396,8 @@ include  __DIR__.'/vendor_web.php';
 
 Route::middleware('auth')->group(function () {
     Route::get('/wallet', [WalletController::class, 'index'])->name('wallet.index');
+    Route::get('/wallet/top-up', [TopUpController::class, 'create'])->name('wallet.topup.create');
+    Route::post('/wallet/top-up', [TopUpController::class, 'store'])->name('wallet.topup.store');
 });
 
 Route::get('/cache', function () {


### PR DESCRIPTION
## Summary
- add TopUpController for wallet top-up
- provide top-up form view
- link top-up page from wallet & nav menu
- record pending wallet top-up transactions

## Testing
- `php` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684e8d96ca7c83298e0b33f836e1ca69