### PR TITLE
Add admin topup filters and status column

### DIFF
--- a/app/Http/Controllers/ADMIN/TopUpController.php
+++ b/app/Http/Controllers/ADMIN/TopUpController.php
@@ -7,6 +7,7 @@ use App\Models\WalletTransaction;
 use App\Services\WalletService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Http\Request;
 
 class TopUpController extends Controller
 {
@@ -20,13 +21,36 @@ class TopUpController extends Controller
     /**
      * Display pending top-up requests.
      */
-    public function index()
+    public function index(Request $request)
     {
-        $transactions = WalletTransaction::with('wallet.getUser')
-            ->where('source', 'topup')
-            ->where('status', 0)
-            ->orderByDesc('created_at')
-            ->paginate(10);
+        $query = WalletTransaction::with('wallet.getUser')
+            ->where('source', 'topup');
+
+        if ($request->filled('status') && $request->status !== 'all') {
+            $statusMap = ['pending' => 0, 'approved' => 1];
+            if (isset($statusMap[$request->status])) {
+                $query->where('status', $statusMap[$request->status]);
+            }
+        }
+
+        if ($request->filled('user')) {
+            $query->whereHas('wallet.getUser', function ($q) use ($request) {
+                $q->where('id', $request->user)
+                    ->orWhere('email', 'like', '%' . $request->user . '%');
+            });
+        }
+
+        if ($request->filled('from')) {
+            $query->whereDate('created_at', '>=', $request->from);
+        }
+
+        if ($request->filled('to')) {
+            $query->whereDate('created_at', '<=', $request->to);
+        }
+
+        $transactions = $query->orderByDesc('created_at')
+            ->paginate(10)
+            ->appends($request->query());
 
         return view('admin.topups.index', compact('transactions'));
     }

--- a/resources/views/admin/topups/index.blade.php
+++ b/resources/views/admin/topups/index.blade.php
@@ -3,17 +3,56 @@
 @endphp
 @extends('admin.layouts.app')
 @section('head_scripts')
-    <title>Pending Top-Ups</title>
+    <title>Top-Up Requests</title>
 @endsection
 @section('content')
     <div class="tp_main_content_wrappo">
         <div class="tp_tab_wrappo">
-            <h4 class="tp_heading">Danh sách nạp chờ duyệt</h4>
+            <h4 class="tp_heading">Danh sách nạp tiền</h4>
         </div>
         <div class="tp_tab_content">
             <div class="row">
                 <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
                     <div class="tp_table_box">
+                        @if(session('success'))
+                            <div class="alert alert-success">{{ session('success') }}</div>
+                        @endif
+                        <div class="tp_product_head_search">
+                            <form action="" class="w-100">
+                                <div class="row mt-2">
+                                    <div class="col-lg-2">
+                                        <div class="tp_form_wrapper">
+                                            <select name="status" class="form-control">
+                                                <option value="all" @if(request('status', 'all')=='all') selected @endif>Tất cả trạng thái</option>
+                                                <option value="pending" @if(request('status')=='pending') selected @endif>Pending</option>
+                                                <option value="approved" @if(request('status')=='approved') selected @endif>Approved</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-3">
+                                        <div class="tp_form_wrapper">
+                                            <input type="text" name="user" class="form-control" placeholder="User ID hoặc Email" value="{{ request('user') }}">
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-2">
+                                        <div class="tp_form_wrapper">
+                                            <input type="date" name="from" class="form-control" value="{{ request('from') }}">
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-2">
+                                        <div class="tp_form_wrapper">
+                                            <input type="date" name="to" class="form-control" value="{{ request('to') }}">
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-3">
+                                        <div class="tp_prosearch_btn">
+                                            <button type="submit" class="tp_btn">Lọc</button>
+                                            <a href="{{ route('admin.topups.index') }}" class="tp_btn"><i class="fa fa-refresh"></i></a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
                         <div class="table-responsive">
                             <table class="table">
                                 <thead>
@@ -23,27 +62,37 @@
                                         <th>Email</th>
                                         <th>Số tiền</th>
                                         <th>Ngày</th>
+                                        <th>Status</th>
                                         <th>Thao tác</th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                     @forelse ($transactions as $index => $item)
-                                        <tr>
+                                        <tr @class(['table-success' => $item->status == 1])>
                                             <td>{{ $transactions->firstItem() + $index }}</td>
                                             <td>{{ $item->wallet->getUser->full_name }}</td>
                                             <td>{{ $item->wallet->getUser->email }}</td>
                                             <td>{{ number_format($item->amount, 0, ',', '.') }} VND</td>
                                             <td>{{ $item->created_at }}</td>
                                             <td>
-                                                <form action="{{ route('admin.topups.approve', $item->id) }}" method="POST">
-                                                    @csrf
-                                                    <button type="submit" class="btn btn-sm btn-primary">Duyệt</button>
-                                                </form>
+                                                @if($item->status == 0)
+                                                    <span class="badge bg-warning text-dark">Pending</span>
+                                                @else
+                                                    <span class="badge bg-success">Approved</span>
+                                                @endif
+                                            </td>
+                                            <td>
+                                                @if($item->status == 0)
+                                                    <form action="{{ route('admin.topups.approve', $item->id) }}" method="POST">
+                                                        @csrf
+                                                        <button type="submit" class="btn btn-sm btn-primary">Duyệt</button>
+                                                    </form>
+                                                @endif
                                             </td>
                                         </tr>
                                     @empty
                                         <tr>
-                                            <td colspan="6" class="text-center">Không có dữ liệu.</td>
+                                            <td colspan="7" class="text-center">Không có dữ liệu.</td>
                                         </tr>
                                     @endforelse
                                 </tbody>


### PR DESCRIPTION
## Summary
- add request-based filters for admin top-ups
- show session success message and filtering form in admin topups
- add status column with badges and row highlighting
- show approve button only when pending

## Testing
- `composer install --no-interaction --no-progress` *(fails: ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_b_684e954419ac8329a53d3c6e80933995