### PR TITLE
Add vendor bank account menu entry

### DIFF
--- a/resources/views/author/layouts/menu.blade.php
+++ b/resources/views/author/layouts/menu.blade.php
@@ -46,6 +46,14 @@
                     <p>Ví</p>
                 </a>
             </li>
+            <li class="@if (Route::is('vendor.bank_accounts.*')) active @endif">
+                <a href="{{ route('vendor.bank_accounts.index') }}">
+                    <span class="">
+                        <!-- icon -->
+                    </span>
+                    <p>Tài khoản ngân hàng</p>
+                </a>
+            </li>
             <li class="@if (Route::is('vendor.profile')) active @endif">
                 <a href="{{ route('vendor.profile') }}">
                     <span class="">

--- a/resources/views/author/wallet/index.blade.php
+++ b/resources/views/author/wallet/index.blade.php
@@ -144,11 +144,18 @@
 
                             <div class="form-group">
                                 <label class="ap_label">Tài khoản ngân hàng</label>
-                                <select name="bank_account_id" class="form-control">
-                                    @foreach($accounts as $acc)
-                                        <option value="{{ $acc->id }}">{{ $acc->bank_name }} - {{ $acc->account_number }}</option>
-                                    @endforeach
-                                </select>
+                                @if($accounts->isEmpty())
+                                    <p class="text-muted">
+                                        Chưa có tài khoản ngân hàng.
+                                        <a href="{{ route('vendor.bank_accounts.index') }}">Thêm mới</a>
+                                    </p>
+                                @else
+                                    <select name="bank_account_id" class="form-control">
+                                        @foreach($accounts as $acc)
+                                            <option value="{{ $acc->id }}">{{ $acc->bank_name }} - {{ $acc->account_number }}</option>
+                                        @endforeach
+                                    </select>
+                                @endif
                             </div>
                             <div class="form-group mt-2">
                                 <label class="ap_label">Nhập số tiền </label>


### PR DESCRIPTION
## Summary
- show "Tài khoản ngân hàng" link in vendor sidebar
- in withdrawal modal show hint to add bank account if none exist

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_684ec0bbaa9c8329afdf26c055801fc4