### PR TITLE
Add metadata support to AdminActionLog

### DIFF
--- a/app/Models/AdminActionLog.php
+++ b/app/Models/AdminActionLog.php
@@ -14,5 +14,10 @@ class AdminActionLog extends Model
         'target_type',
         'target_id',
         'description',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
     ];
 }

--- a/app/Services/AdminActionLogService.php
+++ b/app/Services/AdminActionLogService.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AdminActionLog;
+use Illuminate\Database\Eloquent\Model;
+
+class AdminActionLogService
+{
+    public static function log(int $adminId, string $action, Model $subject, array $meta = []): void
+    {
+        AdminActionLog::create([
+            'admin_id'    => $adminId,
+            'action'      => $action,
+            'target_type' => $subject->getMorphClass(),
+            'target_id'   => $subject->getKey(),
+            'metadata'    => $meta,
+        ]);
+    }
+}

--- a/database/migrations/2024_05_30_000006_add_metadata_to_admin_action_logs.php
+++ b/database/migrations/2024_05_30_000006_add_metadata_to_admin_action_logs.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('admin_action_logs', function (Blueprint $table) {
+            $table->json('metadata')->nullable()->after('description');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('admin_action_logs', function (Blueprint $table) {
+            $table->dropColumn('metadata');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add migration for metadata column on admin_action_logs
- cast metadata to array in AdminActionLog model and make fillable
- add AdminActionLogService with `log` method

## Testing
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684ec6533604832989569f62b4593fd9