### PR TITLE
Add withdrawal approval test and assert admin logs

### DIFF
--- a/tests/Feature/AdminTopUpApprovalTest.php
+++ b/tests/Feature/AdminTopUpApprovalTest.php
@@ -67,6 +67,11 @@ class AdminTopUpApprovalTest extends TestCase
             'status' => 1,
         ]);
 
+        $this->assertDatabaseHas('admin_action_logs', [
+            'action' => 'topup_approve',
+            'target_id' => $txId,
+        ]);
+
         $this->assertDatabaseHas('wallets', [
             'id' => $walletId,
             'balance' => 20000,

--- a/tests/Feature/AdminWithdrawalApprovalTest.php
+++ b/tests/Feature/AdminWithdrawalApprovalTest.php
@@ -1,0 +1,90 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\{User, Wallet};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use App\Services\WalletService;
+use Tests\TestCase;
+use App\Models\{UserBankAccount, WalletTransactionBankAccount};
+
+class AdminWithdrawalApprovalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_approve_withdrawal_request(): void
+    {
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+
+        $admin = User::create([
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+            'full_name' => 'Admin',
+            'role' => 0,
+            'role_type' => 'ADMIN',
+            'is_email_verified' => 1,
+        ]);
+
+        $user = User::create([
+            'email' => 'vendor@example.com',
+            'password' => bcrypt('password'),
+            'full_name' => 'Vendor',
+            'role' => 2,
+            'role_type' => 'VENDOR',
+            'is_email_verified' => 1,
+        ]);
+
+        DB::table('settings')->insert([
+            'key' => 'min_withdraw',
+            'short_value' => '10',
+        ]);
+
+        $walletId = Str::uuid()->toString();
+        DB::table('wallets')->insert([
+            'id' => $walletId,
+            'user_id' => $user->id,
+            'balance' => 100,
+            'type' => 'DEFAULT',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $account = UserBankAccount::create([
+            'user_id' => $user->id,
+            'bank_name' => 'Bank',
+            'account_number' => '123',
+            'account_holder' => 'Holder',
+        ]);
+
+        $service = new WalletService();
+        $service->debit($user->id, 50, 'WITHDRAW');
+        $transaction = DB::table('wallet_transactions')->where('wallet_id', $walletId)->latest()->first();
+        WalletTransactionBankAccount::create([
+            'wallet_transaction_id' => $transaction->id,
+            'bank_account_id' => $account->id,
+        ]);
+
+        $response = $this->actingAs($admin)
+            ->post(route('admin.wallet.update_request'), [
+                'id' => $transaction->id,
+                'status' => 1,
+                'note' => 'Approved',
+            ]);
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('wallets', [
+            'id' => $walletId,
+            'balance' => 50,
+        ]);
+        $this->assertDatabaseHas('wallet_transactions', [
+            'id' => $transaction->id,
+            'status' => 1,
+        ]);
+        $this->assertDatabaseHas('admin_action_logs', [
+            'admin_id' => $admin->id,
+            'action' => 'withdraw_approve',
+            'target_id' => $transaction->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- assert admin action logging on top-up approval
- add a feature test covering admin approval of withdrawal requests

## Testing
- `vendor/bin/phpunit --testsuite Feature` *(fails: Expected response status code [200] but received 500)*

------
https://chatgpt.com/codex/tasks/task_b_684ec7e3743c8329b01de79024c26698