### PR TITLE
Fix admin action log service

### DIFF
--- a/app/Http/Controllers/ADMIN/TopUpController.php
+++ b/app/Http/Controllers/ADMIN/TopUpController.php
@@ -64,9 +64,9 @@ class TopUpController extends Controller
         $this->walletService->approveTopUp($id, 'Admin approved top-up');
 
         AdminActionLogService::log(
+            auth()->id(),
             'topup_approve',
-            'wallet_transaction',
-            $id,
+            $transaction,
             ['amount' => $transaction->amount]
         );
 
@@ -90,9 +90,9 @@ class TopUpController extends Controller
         $transaction->save();
 
         AdminActionLogService::log(
+            auth()->id(),
             'topup_reject',
-            'wallet_transaction',
-            $id,
+            $transaction,
             ['note' => $request->note]
         );
 

--- a/app/Http/Controllers/ADMIN/WalletController.php
+++ b/app/Http/Controllers/ADMIN/WalletController.php
@@ -123,18 +123,18 @@ class WalletController extends Controller
                     'Withdraw rejected'
                 );
                 AdminActionLogService::log(
+                    auth()->id(),
                     'withdraw_reject',
-                    'wallet_transaction',
-                    $data->id,
+                    $data,
                     ['note' => $request->note]
                 );
             }
 
             if ((int) $request->status === 1 && $data->status != 1) {
                 AdminActionLogService::log(
+                    auth()->id(),
                     'withdraw_approve',
-                    'wallet_transaction',
-                    $data->id,
+                    $data,
                     ['note' => $request->note]
                 );
             }

--- a/app/Services/AdminActionLogService.php
+++ b/app/Services/AdminActionLogService.php
@@ -3,19 +3,6 @@
 namespace App\Services;
 
 use App\Models\AdminActionLog;
-
-
-class AdminActionLogService
-{
-    public static function log(string $action, string $targetType, string $targetId, array $metadata = []): void
-    {
-        AdminActionLog::create([
-            'admin_id' => auth()->id(),
-            'action' => $action,
-            'target_type' => $targetType,
-            'target_id' => $targetId,
-            'description' => $metadata ? json_encode($metadata) : null,
-
 use Illuminate\Database\Eloquent\Model;
 
 class AdminActionLogService
@@ -28,7 +15,6 @@ class AdminActionLogService
             'target_type' => $subject->getMorphClass(),
             'target_id'   => $subject->getKey(),
             'metadata'    => $meta,
-
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- simplify AdminActionLogService
- update logging calls in admin controllers
- pass model instances and admin id to log service

## Testing
- `php artisan test tests/Feature/AdminWithdrawalRejectTest.php`
- `php artisan test tests/Feature/AdminWithdrawalApprovalTest.php`
- `php artisan test tests/Feature/AdminTopUpApprovalTest.php`
- `php artisan test` *(fails: DefaultBankAccountTest)*

------
https://chatgpt.com/codex/tasks/task_b_684ecabec6648329ba190a2411631b3e