### PR TITLE
Restore original theme colors

### DIFF
--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -10,15 +10,18 @@
   --input-bg: #ffffff;
   --input-border: #ced4da;
   /* legacy variable aliases */
-  --theme-color: var(--color-primary);
-  --secondary-color: var(--color-secondary);
-  --text-color: var(--text-main);
-  --menu-heading-color: var(--text-main);
-  --tp-text-color: var(--text-main);
-  --tp-body-bg-color: var(--bg-main);
-  --background: var(--bg-main);
-  --bgcolour: var(--bg-main);
+  --theme-color: #216fff;
+  --secondary-color: #566c8e;
+  --text-color: #53627a;
+  --background: #eff5fc;
+  --bgcolour: #f5f8fa;
+  --menu-heading-color: #002533;
   --white-color: #ffffff;
+  --yellow-color: #fba948;
+  --blue-color: #1778f2;
+  --tp-body-bg-color: #f5f7fa;
+  --tp-text-color: rgba(0, 0, 0, 0.87);
+  --tp-border-color: rgba(0, 0, 0, 0.1);
 }
 
 body {
@@ -59,6 +62,7 @@ a {
   color: #fff;
 }
 
+/*
 .dark {
   --color-primary: #00796B;
   --color-secondary: #585C66;
@@ -80,3 +84,4 @@ a {
   --background: var(--bg-main);
   --bgcolour: var(--bg-main);
 }
+*/


### PR DESCRIPTION
## Summary
- restore fixed color values in theme.css
- disable dark mode overrides

## Testing
- `npm run build` *(fails: vite not found)*
- `./vendor/bin/phpunit --testdox` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684eed0a37208329ba02946448a5a258