### PR TITLE
Remove frontend dark mode toggle

### DIFF
--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="vi" class="{{ session('theme', 'light') === 'dark' ? 'dark' : '' }}">
+<html lang="vi">
 <head>
     @php
         $ASSET_URL = asset('admin-theme/assets') . '/';

--- a/resources/views/frontend/layout/nav.blade.php
+++ b/resources/views/frontend/layout/nav.blade.php
@@ -172,7 +172,6 @@
             @else
                 <a href="{{ route('frontend.sign-in', app()->getLocale()) }}" class="tp_btn">@lang('master.header.Login')</a>
             @endif
-            <button id="dark-mode-toggle" class="tp_btn" type="button">Toggle Theme</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- drop dark mode button from the frontend navbar
- clean up session-based theme class in admin layout

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f0d10d05c8329a088c07c43e0dd31