### PR TITLE
Fix CSS variable references

### DIFF
--- a/public/admin-theme/assets/css/style.css
+++ b/public/admin-theme/assets/css/style.css
@@ -1089,7 +1089,7 @@ a.setting-tab i.fa-google{
 	height: auto;
 }
 .tp_catset_box label sup{
-        color: var(--color-danger);
+        color: var(--tp-error-color);
     top: -1px;
     font-weight: 700;
     left: 2px;
@@ -2807,7 +2807,7 @@ hr:not([size]) {
     position: absolute;
     top: 10px;
     right: 15px;
-    background-color: var(--color-danger);
+    background-color: var(--tp-error-color);
     border-radius: 5px;
     color: var(--tp-white-color);
     padding: 0px 8px;
@@ -2841,7 +2841,7 @@ hr:not([size]) {
 }
 .condition-toggle label .condition-toggle-switch {
     transition: background-color 0.3s cubic-bezier(0, 1, 0.5, 1);
-    background: var(--color-primary);
+    background: var(--theme-color);
 }
 .condition-toggle label .condition-toggle-switch {
     position: relative;

--- a/public/user-theme/assets/css/style.css
+++ b/public/user-theme/assets/css/style.css
@@ -3797,7 +3797,7 @@ label.error, span.error {
 .tp_payproduct_list ul li h5 a span {
   height: 30px;
   width: 30px;
-  background-color: var(--color-primary);
+  background-color: var(--theme-color);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- update admin theme CSS to use legacy variable names
- update user theme CSS to use legacy variable names

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f0d185f9883299792f3ca07a267df