### PR TITLE
Add theme mode settings

### DIFF
--- a/app/Http/Controllers/ADMIN/SettingController.php
+++ b/app/Http/Controllers/ADMIN/SettingController.php
@@ -88,7 +88,15 @@ class SettingController extends Controller
 
     public function updateSettings(Request $request)
     {
-        $input = $request->all();
+        $input = $request->except('_token');
+        if (isset($input['theme_mode'])) {
+            $obj = Setting::firstOrNew(['key' => 'theme_mode']);
+            $obj->key = 'theme_mode';
+            $obj->short_value = $input['theme_mode'];
+            $obj->save();
+            $this->dotenvEditor('theme_mode', $input['theme_mode']);
+            unset($input['theme_mode']);
+        }
       
         if(count($input) > 0){
             foreach ($input as $key => $value)

--- a/database/migrations/2025_06_16_000007_add_theme_mode_to_settings_table.php
+++ b/database/migrations/2025_06_16_000007_add_theme_mode_to_settings_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            if (!Schema::hasColumn('settings', 'theme_mode')) {
+                $table->enum('theme_mode', ['light', 'dark', 'auto'])->default('light')->after('is_active');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            if (Schema::hasColumn('settings', 'theme_mode')) {
+                $table->dropColumn('theme_mode');
+            }
+        });
+    }
+};
+

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="vi">
+<html lang="vi"@if($setting->theme_mode == 'dark' || ($setting->theme_mode == 'auto' && request()->cookie('theme') == 'dark')) class="dark"@endif>
 <head>
     @php
         $ASSET_URL = asset('admin-theme/assets') . '/';
@@ -47,6 +47,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="{{asset('admin-theme/my_assets/select2.min.css')}}" rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/style.css" />
+    @if($setting->theme_mode == 'dark' || ($setting->theme_mode == 'auto' && request()->cookie('theme') == 'dark'))
+        <link rel="stylesheet" href="{{ asset('css/dark-override.css') }}">
+    @endif
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/dropzone.min.css"/>
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/dropzone-custom.css"/>
     <link rel="stylesheet" href="{{ asset('admin-theme/my_assets/iziToast.min.css') }}">
@@ -103,6 +106,12 @@
     <!-- button loader validation -->
     <script src="{{asset('user-theme/my_assets/jquery.buttonLoader.min.js')}}"></script>
     <script src="{{asset('admin-theme/my_assets/common.js') }}"></script>
+    <script>
+        function setTheme(mode) {
+            document.cookie = 'theme=' + mode + ';path=/';
+            document.documentElement.classList.toggle('dark', mode === 'dark');
+        }
+    </script>
     <script>
         var ASSET_URL = "{{ asset('admin-theme') . '/' }}";
         var BASE_URL = "{{ url('/') }}";

--- a/resources/views/admin/setting/color.blade.php
+++ b/resources/views/admin/setting/color.blade.php
@@ -56,6 +56,20 @@
                                         </div>
                                     </div>
 
+                                    <div class="col-lg-6 col-md-12">
+                                        <div class="tp_form_wrapper">
+                                            <label class="mb-2">Chế độ giao diện</label>
+                                            <div class="tp_custom_select">
+                                                <select class="form-select" name="theme_mode">
+                                                    @php $modes = ['light' => 'Light', 'dark' => 'Dark', 'auto' => 'Auto']; @endphp
+                                                    @foreach ($modes as $key => $val)
+                                                        <option value="{{ $key }}" @if(@$data->theme_mode == $key) selected @endif>{{ $val }}</option>
+                                                    @endforeach
+                                                </select>
+                                            </div>
+                                        </div>
+                                    </div>
+
                                     <div class="col-lg-12 col-md-12">
                                         <div class="tp_seo_btn">
                                             <button type="submit" class="tp_btn"

--- a/resources/views/author/layouts/app.blade.php
+++ b/resources/views/author/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="vi">
+<html lang="vi"@if($setting->theme_mode == 'dark' || ($setting->theme_mode == 'auto' && request()->cookie('theme') == 'dark')) class="dark"@endif>
 <head>
     @php
         $ASSET_URL = asset('admin-theme/assets') . '/';
@@ -46,6 +46,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="{{asset('admin-theme/my_assets/select2.min.css')}}" rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/style.css" />
+    @if($setting->theme_mode == 'dark' || ($setting->theme_mode == 'auto' && request()->cookie('theme') == 'dark'))
+        <link rel="stylesheet" href="{{ asset('css/dark-override.css') }}">
+    @endif
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/dropzone.min.css"/>
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/dropzone-custom.css"/>
     <link rel="stylesheet" href="{{ asset('admin-theme/my_assets/iziToast.min.css') }}">
@@ -96,6 +99,12 @@
     <!-- button laoder validation -->
     <script src="{{asset('user-theme/my_assets/jquery.buttonLoader.min.js')}}"></script>
     <script src="{{asset('admin-theme/my_assets/common.js') }}"></script>
+    <script>
+        function setTheme(mode) {
+            document.cookie = 'theme=' + mode + ';path=/';
+            document.documentElement.classList.toggle('dark', mode === 'dark');
+        }
+    </script>
     
     <script>
         var ASSET_URL = "{{ asset('admin-theme') . '/' }}";


### PR DESCRIPTION
## Summary
- add migration for `theme_mode` column on settings
- store `theme_mode` in `SettingController`
- expose theme mode selector on admin color settings
- load dark override css based on theme mode
- support runtime switching using helper `setTheme`

## Testing
- `composer test` *(fails: composer not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684ff1148d708329ae8dd01ef4f7fcbb