### PR TITLE
Add default theme mode seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,8 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Default Settings
+
+Running `php artisan db:seed` will insert the default theme mode setting with a value of `light`.
 "# laravel-theme-portal-2" 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,8 @@ class DatabaseSeeder extends Seeder
         //     'name' => 'Test User',
         //     'email' => 'test@example.com',
         // ]);
-    
+
+        $this->call(ThemeModeSettingSeeder::class);
+
     }
 }

--- a/database/seeders/ThemeModeSettingSeeder.php
+++ b/database/seeders/ThemeModeSettingSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Admin\Setting;
+
+class ThemeModeSettingSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Setting::updateOrCreate(
+            ['key' => 'theme_mode'],
+            ['short_value' => 'light']
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a seeder that stores the default theme mode
- invoke the new seeder from `DatabaseSeeder`
- document database seeding instructions in README

## Testing
- `composer install` *(fails: command not found)*
- `php artisan --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ff7b72e8c8329a1ec1a6cfd0f19a2