### PR TITLE
Set default theme mode to light

### DIFF
--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="vi"@if($setting->theme_mode == 'dark' || ($setting->theme_mode == 'auto' && request()->cookie('theme') == 'dark')) class="dark"@endif>
+<html lang="vi"@if(($setting->theme_mode ?? 'light') == 'dark' || (($setting->theme_mode ?? 'light') == 'auto' && request()->cookie('theme') == 'dark')) class="dark"@endif>
 <head>
     @php
         $ASSET_URL = asset('admin-theme/assets') . '/';
@@ -47,7 +47,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="{{asset('admin-theme/my_assets/select2.min.css')}}" rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/style.css" />
-    @if($setting->theme_mode == 'dark' || ($setting->theme_mode == 'auto' && request()->cookie('theme') == 'dark'))
+    @if(($setting->theme_mode ?? 'light') == 'dark' || (($setting->theme_mode ?? 'light') == 'auto' && request()->cookie('theme') == 'dark'))
         <link rel="stylesheet" href="{{ asset('css/dark-override.css') }}">
     @endif
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/dropzone.min.css"/>

--- a/resources/views/author/layouts/app.blade.php
+++ b/resources/views/author/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="vi"@if($setting->theme_mode == 'dark' || ($setting->theme_mode == 'auto' && request()->cookie('theme') == 'dark')) class="dark"@endif>
+<html lang="vi"@if(($setting->theme_mode ?? 'light') == 'dark' || (($setting->theme_mode ?? 'light') == 'auto' && request()->cookie('theme') == 'dark')) class="dark"@endif>
 <head>
     @php
         $ASSET_URL = asset('admin-theme/assets') . '/';
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="{{asset('admin-theme/my_assets/select2.min.css')}}" rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/style.css" />
-    @if($setting->theme_mode == 'dark' || ($setting->theme_mode == 'auto' && request()->cookie('theme') == 'dark'))
+    @if(($setting->theme_mode ?? 'light') == 'dark' || (($setting->theme_mode ?? 'light') == 'auto' && request()->cookie('theme') == 'dark'))
         <link rel="stylesheet" href="{{ asset('css/dark-override.css') }}">
     @endif
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/dropzone.min.css"/>


### PR DESCRIPTION
## Summary
- default to `light` theme if no theme option is set

## Testing
- `npm --version`
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ff7b1a1b8832998c54dfb33c8e230