### PR TITLE
Remove dark mode from admin and author layouts

### DIFF
--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="vi"@if(($setting->theme_mode ?? 'light') == 'dark' || (($setting->theme_mode ?? 'light') == 'auto' && request()->cookie('theme') == 'dark')) class="dark"@endif>
+<html lang="vi">
 <head>
     @php
         $ASSET_URL = asset('admin-theme/assets') . '/';
@@ -47,9 +47,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="{{asset('admin-theme/my_assets/select2.min.css')}}" rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/style.css" />
-    @if(($setting->theme_mode ?? 'light') == 'dark' || (($setting->theme_mode ?? 'light') == 'auto' && request()->cookie('theme') == 'dark'))
-        <link rel="stylesheet" href="{{ asset('css/dark-override.css') }}">
-    @endif
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/dropzone.min.css"/>
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/dropzone-custom.css"/>
     <link rel="stylesheet" href="{{ asset('admin-theme/my_assets/iziToast.min.css') }}">

--- a/resources/views/author/layouts/app.blade.php
+++ b/resources/views/author/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="vi"@if(($setting->theme_mode ?? 'light') == 'dark' || (($setting->theme_mode ?? 'light') == 'auto' && request()->cookie('theme') == 'dark')) class="dark"@endif>
+<html lang="vi">
 <head>
     @php
         $ASSET_URL = asset('admin-theme/assets') . '/';
@@ -46,9 +46,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="{{asset('admin-theme/my_assets/select2.min.css')}}" rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/style.css" />
-    @if(($setting->theme_mode ?? 'light') == 'dark' || (($setting->theme_mode ?? 'light') == 'auto' && request()->cookie('theme') == 'dark'))
-        <link rel="stylesheet" href="{{ asset('css/dark-override.css') }}">
-    @endif
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/dropzone.min.css"/>
     <link rel="stylesheet" type="text/css" href="{{ $ASSET_URL }}css/dropzone-custom.css"/>
     <link rel="stylesheet" href="{{ asset('admin-theme/my_assets/iziToast.min.css') }}">


### PR DESCRIPTION
## Summary
- disable conditional `class="dark"` on the admin and author layout `<html>` tags
- remove dark mode CSS inclusion from admin and author layouts

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685004e88150832991fc34ef8c708fdf