### PR TITLE
Add vendor bank account editing and bank list

### DIFF
--- a/app/Http/Controllers/Author/BankAccountController.php
+++ b/app/Http/Controllers/Author/BankAccountController.php
@@ -11,7 +11,8 @@ class BankAccountController extends Controller
     public function index()
     {
         $accounts = UserBankAccount::where('user_id', auth()->id())->paginate(10);
-        return view('author.bank_account.index', compact('accounts'));
+        $banks = config('banks');
+        return view('author.bank_account.index', compact('accounts','banks'));
     }
 
     public function store(Request $request)
@@ -25,18 +26,46 @@ class BankAccountController extends Controller
         if ($validator->fails()) {
             return back()->withErrors($validator)->withInput();
         }
-        if ($request->is_default) {
-            UserBankAccount::where('user_id', auth()->id())->update(['is_default' => false]);
-        }
         UserBankAccount::create([
             'user_id' => auth()->id(),
             'bank_name' => $request->bank_name,
             'account_number' => $request->account_number,
             'account_holder' => $request->account_holder,
             'method' => $request->method,
-            'is_default' => $request->is_default ? true : false,
+            'is_default' => $request->has('is_default'),
         ]);
         return redirect()->route('vendor.bank_accounts.index')->with('success', 'Bank account saved.');
+    }
+
+    public function edit($id)
+    {
+        $account = UserBankAccount::where('user_id', auth()->id())->findOrFail($id);
+        $banks = config('banks');
+        return view('author.bank_account.edit', compact('account', 'banks'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $rules = [
+            'bank_name' => 'required',
+            'account_number' => 'required',
+            'account_holder' => 'required',
+        ];
+        $validator = Validator::make($request->all(), $rules);
+        if ($validator->fails()) {
+            return back()->withErrors($validator)->withInput();
+        }
+
+        $account = UserBankAccount::where('user_id', auth()->id())->findOrFail($id);
+        $account->update([
+            'bank_name' => $request->bank_name,
+            'account_number' => $request->account_number,
+            'account_holder' => $request->account_holder,
+            'method' => $request->method,
+            'is_default' => $request->has('is_default'),
+        ]);
+
+        return redirect()->route('vendor.bank_accounts.index')->with('success', 'Bank account updated.');
     }
 
     public function destroy($id)

--- a/app/Models/UserBankAccount.php
+++ b/app/Models/UserBankAccount.php
@@ -8,6 +8,19 @@ class UserBankAccount extends Model
 {
     use HasFactory;
 
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::saving(function ($model) {
+            if ($model->is_default) {
+                static::where('user_id', $model->user_id)
+                    ->where('id', '!=', $model->id ?? 0)
+                    ->update(['is_default' => false]);
+            }
+        });
+    }
+
     protected $fillable = [
         'user_id',
         'bank_name',

--- a/config/banks.php
+++ b/config/banks.php
@@ -1,0 +1,11 @@
+<?php
+return [
+    'Vietcombank',
+    'BIDV',
+    'Techcombank',
+    'MB',
+    'ACB',
+    'VPBank',
+    'Sacombank',
+    'Agribank',
+];

--- a/resources/views/author/bank_account/edit.blade.php
+++ b/resources/views/author/bank_account/edit.blade.php
@@ -1,0 +1,44 @@
+@extends('author.layouts.app')
+@section('content')
+<div class="tp_main_content_wrappo">
+    <div class="tp_tab_wrappo">
+        <h4 class="tp_heading">Edit Bank Account</h4>
+    </div>
+    <div class="tp_tab_content">
+        <div class="row">
+            <div class="col-md-6">
+                <form method="POST" action="{{ route('vendor.bank_accounts.update', $account->id) }}">
+                    @csrf
+                    @method('PUT')
+                    <div class="tp_form_wrapper">
+                        <label class="mb-2">Bank Name</label>
+                        <select name="bank_name" class="form-control" required>
+                            @foreach($banks as $bank)
+                                <option value="{{ $bank }}" @if($account->bank_name == $bank) selected @endif>{{ $bank }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="tp_form_wrapper">
+                        <label class="mb-2">Account Number</label>
+                        <input type="text" name="account_number" class="form-control" value="{{ $account->account_number }}" required>
+                    </div>
+                    <div class="tp_form_wrapper">
+                        <label class="mb-2">Account Holder</label>
+                        <input type="text" name="account_holder" class="form-control" value="{{ $account->account_holder }}" required>
+                    </div>
+                    <div class="tp_form_wrapper">
+                        <label class="mb-2">Method</label>
+                        <input type="text" name="method" class="form-control" value="{{ $account->method }}">
+                    </div>
+                    <div class="form-check mt-2">
+                        <input class="form-check-input" type="checkbox" name="is_default" value="1" id="is_default" @if($account->is_default) checked @endif>
+                        <label class="form-check-label" for="is_default">Default</label>
+                    </div>
+                    <button type="submit" class="btn btn-primary mt-3">Update</button>
+                    <a href="{{ route('vendor.bank_accounts.index') }}" class="btn btn-link mt-3">Cancel</a>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/author/bank_account/index.blade.php
+++ b/resources/views/author/bank_account/index.blade.php
@@ -14,7 +14,12 @@
                     @csrf
                     <div class="tp_form_wrapper">
                         <label class="mb-2">Bank Name</label>
-                        <input type="text" name="bank_name" class="form-control" required>
+                        <select name="bank_name" class="form-control" required>
+                            <option value="">Select bank</option>
+                            @foreach($banks as $bank)
+                                <option value="{{ $bank }}">{{ $bank }}</option>
+                            @endforeach
+                        </select>
                     </div>
                     <div class="tp_form_wrapper">
                         <label class="mb-2">Account Number</label>
@@ -45,6 +50,7 @@
                             <th>Holder</th>
                             <th>Default</th>
                             <th></th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -58,6 +64,9 @@
                                 @if($account->is_default)
                                     <span class="badge bg-primary">Default</span>
                                 @endif
+                            </td>
+                            <td>
+                                <a href="{{ route('vendor.bank_accounts.edit',$account->id) }}" class="btn btn-sm btn-secondary">Edit</a>
                             </td>
                             <td>
                                 <form method="POST" action="{{ route('vendor.bank_accounts.destroy',$account->id) }}">

--- a/routes/vendor_web.php
+++ b/routes/vendor_web.php
@@ -61,6 +61,8 @@ Route::group(['prefix' => 'author'], function () {
         Route::controller(BankAccountController::class)->prefix('bank-accounts')->group(function(){
             Route::get('/', 'index')->name('vendor.bank_accounts.index');
             Route::post('/', 'store')->name('vendor.bank_accounts.store');
+            Route::get('{id}/edit', 'edit')->name('vendor.bank_accounts.edit');
+            Route::put('{id}', 'update')->name('vendor.bank_accounts.update');
             Route::delete('{id}', 'destroy')->name('vendor.bank_accounts.destroy');
         });
        


### PR DESCRIPTION
## Summary
- list popular Vietnamese banks in new config file
- only allow one default bank account per user via model hook
- show dropdown of banks when creating accounts
- add ability for vendors to edit bank accounts
- expose edit/update routes

## Testing
- `php` or composer not available so tests could not run

------
https://chatgpt.com/codex/tasks/task_b_685141f085a083299ffa54a15627455d