### PR TITLE
Implement Vietnamese slug conversion

### DIFF
--- a/public/admin-theme/my_assets/common.js
+++ b/public/admin-theme/my_assets/common.js
@@ -305,11 +305,33 @@ function update_single_status2(url, status, confirm_message="") {
     });
 }
 
+function convertViToEn(str) {
+    var unicode = {
+        'a': 'á|à|ả|ã|ạ|ă|ắ|ằ|ẳ|ẵ|ặ|â|ấ|ầ|ẩ|ẫ|ậ',
+        'd': 'đ',
+        'e': 'é|è|ẻ|ẽ|ẹ|ê|ế|ề|ể|ễ|ệ',
+        'i': 'í|ì|ỉ|ĩ|ị',
+        'o': 'ó|ò|ỏ|õ|ọ|ô|ố|ồ|ổ|ỗ|ộ|ơ|ớ|ờ|ở|ỡ|ợ',
+        'u': 'ú|ù|ủ|ũ|ụ|ư|ứ|ừ|ử|ữ|ự',
+        'y': 'ý|ỳ|ỷ|ỹ|ỵ',
+        'A': 'Á|À|Ả|Ã|Ạ|Ă|Ắ|Ằ|Ẳ|Ẵ|Ặ|Â|Ấ|Ầ|Ẩ|Ẫ|Ậ',
+        'D': 'Đ',
+        'E': 'É|È|Ẻ|Ẽ|Ẹ|Ê|Ế|Ề|Ể|Ễ|Ệ',
+        'I': 'Í|Ì|Ỉ|Ĩ|Ị',
+        'O': 'Ó|Ò|Ỏ|Õ|Ọ|Ô|Ố|Ồ|Ổ|Ỗ|Ộ|Ơ|Ớ|Ờ|Ở|Ỡ|Ợ',
+        'U': 'Ú|Ù|Ủ|Ũ|Ụ|Ư|Ứ|Ừ|Ử|Ữ|Ự',
+        'Y': 'Ý|Ỳ|Ỷ|Ỹ|Ỵ'
+    };
+    for (var nonAccent in unicode) {
+        var regex = new RegExp('(' + unicode[nonAccent] + ')', 'gi');
+        str = str.replace(regex, nonAccent);
+    }
+    return str;
+}
+
 $(document).on('keyup paste', '.generate-slug', function() {
-    var str = $(this).val();
-    str = $.trim(str);
-    str = str.replace(/[^a-z-]/gi, '-');
-    str = str.replace(/ /g, '-').replace(/[-]+/g, '-').replace(/[_]+/g, "").replace(/[^\w-]+/g, "");
+    var str = convertViToEn($(this).val().trim());
+    str = str.replace(/\s+/g, '-').replace(/[^a-z0-9-]/gi, '');
     $('.append-slug').val(str.toLowerCase());
 });
 


### PR DESCRIPTION
## Summary
- add `convertViToEn` to translate Vietnamese characters
- sanitize slug fields using the new conversion

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68519fb4e5a0832991522bbf4b32be7b