### PR TITLE
Fix slug generation in PageController

### DIFF
--- a/app/Http/Controllers/ADMIN/PageController.php
+++ b/app/Http/Controllers/ADMIN/PageController.php
@@ -38,7 +38,7 @@ class PageController extends Controller
         return response()->json(['status' => false, 'msg' => $validator->messages()->first()], 400); 
         $obj = Page::firstOrNew(['id'=>$request->id]);
         if(empty($request->id))
-        $obj->slug = $request->slug;
+        $obj->slug = \Str::slug(convert_vi_to_en($request->slug));
         $obj->heading = $request->heading;
         $obj->sub_heading = $request->sub_heading;
         $obj->description = $request->description;


### PR DESCRIPTION
## Summary
- ensure page slugs use `Str::slug(convert_vi_to_en())`

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68519fc026708329b3baa17a185ee109