### PR TITLE
Document slug accent conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,11 @@ The Laravel framework is open-sourced software licensed under the [MIT license](
 ## Default Settings
 
 Running `php artisan db:seed` will insert the default theme mode setting with a value of `light`.
+
+# Slug Generation
+
+The application automatically converts Vietnamese accented characters to their ASCII equivalents before slugs are created. This occurs in both the PHP and JavaScript code:
+
+- **PHP** uses the `convert_vi_to_en` helper in controllers when storing slugs.
+- **JavaScript** defines a matching `convertViToEn` function in `public/admin-theme/my_assets/common.js`. Elements with the `generate-slug` class call this function so the slug field updates in real time without accents.
 "# laravel-theme-portal-2" 

--- a/public/admin-theme/my_assets/common.js
+++ b/public/admin-theme/my_assets/common.js
@@ -1,4 +1,8 @@
 "use strict";
+function convertViToEn(str){
+    return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/đ/g, "d").replace(/Đ/g, "D");
+}
+
 /**
 * Error Message toaster
 */
@@ -305,12 +309,12 @@ function update_single_status2(url, status, confirm_message="") {
     });
 }
 
-$(document).on('keyup paste', '.generate-slug', function() {
-    var str = $(this).val();
+$(document).on("keyup paste", ".generate-slug", function() {
+    var str = convertViToEn($(this).val());
     str = $.trim(str);
-    str = str.replace(/[^a-z-]/gi, '-');
-    str = str.replace(/ /g, '-').replace(/[-]+/g, '-').replace(/[_]+/g, "").replace(/[^\w-]+/g, "");
-    $('.append-slug').val(str.toLowerCase());
+    str = str.replace(/[^a-zA-Z0-9-]/g, "-");
+    str = str.replace(/ /g, "-").replace(/[-]+/g, "-").replace(/[_]+/g, "").replace(/[^\w-]+/g, "");
+    $(".append-slug").val(str.toLowerCase());
 });
 
 // =============================


### PR DESCRIPTION
## Summary
- clarify slug generation with `convert_vi_to_en` helper
- add JS helper `convertViToEn` and use it when generating slugs

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68519fcae2808329b2c3146146b5fd77